### PR TITLE
[PPS-2961] fix: bump pygments to 2.20.0

### DIFF
--- a/docs/decommissioned-platforms/anvil-cite.md
+++ b/docs/decommissioned-platforms/anvil-cite.md
@@ -14,8 +14,8 @@ Please credit the AnVIL Data Commons in your manuscript by citing the following 
 <!-- Links and Images -->
 [AnVIL Platform]: https://gen3.theanvil.io/
 [Gen3.org]: https://gen3.org/
-[img AnVIL logo]: ./img/AnVIL-logo.png
-[img Gen3 logo]: ./img/gen3blue.png
+[img AnVIL logo]: ../img/AnVIL-logo.png
+[img Gen3 logo]: ../img/gen3blue.png
 [doi link]: https://doi.org/10.1016/j.xgen.2021.100085
 [pmid link]: https://pubmed.ncbi.nlm.nih.gov/35199087/
 [pmcid link]: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8863334/

--- a/docs/decommissioned-platforms/ibd-cite.md
+++ b/docs/decommissioned-platforms/ibd-cite.md
@@ -15,8 +15,8 @@ Please credit the Inflammatory Bowel Disease Genetics Consortium Data Commons in
 <!-- Links and Images -->
 [IBDGC Platform]: https://ibdgc.datacommons.io/
 [Gen3.org]: https://gen3.org/
-[img IBDGC logo]: ./img/IBDGC-logo.png
-[img Gen3 logo]: ./img/gen3blue.png
+[img IBDGC logo]: ../img/IBDGC-logo.png
+[img Gen3 logo]: ../img/gen3blue.png
 [Org website]: https://www.ibdgc.org/
 <!--
 [doi link]:

--- a/docs/decommissioned-platforms/vadc-cite.md
+++ b/docs/decommissioned-platforms/vadc-cite.md
@@ -31,8 +31,8 @@ Zhou W, Nielsen JB, Fritsche LG, Dey R, Gabrielsen ME, Wolford BN, LeFaive J, Va
 <!-- Links and Images -->
 [VADC Platform]: https://va.data-commons.org/
 [Gen3.org]: https://gen3.org/
-[img VADC logo]: ./img/vadc-logo.png
-[img Gen3 logo]: ./img/gen3blue.png
+[img VADC logo]: ../img/vadc-logo.png
+[img Gen3 logo]: ../img/gen3blue.png
 <!--
 [doi link]:
 [pmid link]:

--- a/poetry.lock
+++ b/poetry.lock
@@ -779,13 +779,13 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
-    {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
 ]
 
 [package.extras]


### PR DESCRIPTION

<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/PPS-2961

### New Features

### Breaking Changes

### Bug Fixes
Also fixed broken img paths

### Improvements

### Dependency updates
pygments 2.19.2 -> 2.20.0

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
